### PR TITLE
Update future ONNX-related events as of March 16, 2020 

### DIFF
--- a/models-tutorials/docs/CommunityEvents.md
+++ b/models-tutorials/docs/CommunityEvents.md
@@ -10,29 +10,20 @@ ONNX Workshop - Vinitra Swamy, Cecilia Liu, Ashwini Khade
 ONNX Talk - Faith Xu, Emma Ning  
 1:00 – 1:30pm: Research to Production with Open Source Software: High performance model inferencing using ONNX
 
+### [Indy Cloud Conf - virtual](https://2020.indycloudconf.com/schedule/)
+**March 27, 2020 - online**
 
-### [O'Reilly Strata Data and AI Conference, San Jose, CA](https://conferences.oreilly.com/strata-data-ai/)
-**March 15-18, 2020 - San Jose Convention Center  150 W San Carlos St. San Jose, CA 95113**
-
-Nick Pentreath (IBM) will present a talk on ONNX deep learning pipelines.
+2:15pm EDT: Svetlana Levitan will present "Open standards for machine learning model deployment"   
 
 
-### [Codemotion Rome 2020, Rome, Italy](https://events.codemotion.com/conferences/rome/2020/agenda/28-March/)
-**March 28, 2020 - Engineering Department | Università degli Studi Roma Tre** 
+### [Codemotion Rome 2020, Rome, Italy](https://events.codemotion.com/conferences/rome/2020/agenda/12-June/)
+**June 12, 2020 - Engineering Department | Università degli Studi Roma Tre** 
 Via Vito Volterra, 60  Rome, Italy
 
 14:10-14:50  Svetlana Levitan will present "Open standards for machine learning model deployment"  
 
+### [O'Reilly Strata Data and AI Conference, NY, NY](https://conferences.oreilly.com/strata-data-ai/stai-ny)
+**September 14-17, 2020 - NY, NY**
 
-### [Meetup of IBM Developer Netherlands, Amsterdam, Netherlands](https://www.meetup.com/IBM-Code-Amsterdam/events/267875799/)
-**April 2, 2020 - B. Amsterdam  Johan Huizingalaan 763a · Amsterdam**
+Nick Pentreath (IBM) will present a talk on ONNX deep learning pipelines.
 
-15:00-17:00 Workshop "Open source libraries for trusted ML and open standards for model deployment"
-presented by Svetlana Levitan (IBM) 
-
-
-### [Awesome IT Conference at University of Amsterdam](https://awesomeit.nl/)
-**April 3, 2020 - Het Sieraad, Postjesweg 1, Amsterdam, Netherlands**
-
-Svetlana Levitan (IBM) will present a talk and a workshop 
-"Open source libraries for trusted ML and open standards for model deployment"


### PR DESCRIPTION
Codemotion Rome postponed to June, Strata Data and AI merged with NY one in September, Amsterdam events canceled, added virtual Indy Cloud conference on March 26-27.  