### PR TITLE
Update SIG chair list

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -85,11 +85,11 @@ SIG-modelstutorials:
 SIG-chairs:
     - postrational
     - linkerzhang
-    - ebarsoum
+    - gramalingam
     - chinhuang007
-    - vinitra
+    - wenbingl
     - guschmue
-    - houseroad
+    - askhade
 
 
 WG-chairs:


### PR DESCRIPTION
We had several SIG chair changes and the permissions need to reflect that.
Rama replaced Emad as chair for Operators SIG
Wenbing replaced Vinitra as chair for Model Zoo SIG
Ashwini replaced Lu for Arch/Infra SIG


Signed-off-by: Prasanth Pulavarthi <prasanth.pulavarthi@microsoft.com>