### PR TITLE
Update Operators SIG members

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -49,14 +49,13 @@ SIG-operators:
     - daquexian
     - hariharans29
     - skottmckay
+    - matteosal
+    - bowenbao
     approvers:
         - wschin
         - postrational
-        - linkerzhang
         - ebarsoum
-        - bddppq
         - gramalingam
-        - houseroad
 
 
 SIG-converters:


### PR DESCRIPTION
Remove members who are inactive for more than 12 months as per https://github.com/onnx/onnx/tree/master/community
Add @Matteosal (Wolfram) who has made significant contributions to version converter and batchwise recurrent ops and @bowenbao (MS) who has contributed to many ops, shape inference, and tests. 
Approved by @gramalingam (MS) and @postrational (Intel)