### PR TITLE
Update Model Zoo converter SIG leader to Jacky Chen

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -69,8 +69,7 @@ SIG-modelstutorials:
     - faxu
     - EmmaNingMS
     approvers:
-        - ebarsoum
-        - vinitra
+        - jcwchen
         - prasanthpul
         - wenbingl
 
@@ -80,8 +79,7 @@ SIG-chairs:
     - linkerzhang
     - gramalingam
     - kevinch-nv
-    - wenbingl
-    - guschmue
+    - jcwchen
     - askhade
 
 


### PR DESCRIPTION
As approved by Steering Committee on 2/18/2022: https://github.com/onnx/steering-committee/blob/main/meeting-notes/20220218.md

Also remove inactive approvers on model zoo sig