### PR TITLE
update of onnx-mlir contributors

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -26,8 +26,18 @@ SIG-archinfra:
         - caoimhinuibrian
         - chentong319
         - doru1004
-        - migueldeicaza
+        - etiotto
+        - gongsu832
+        - gramalingam
+        - imaihal
+        - manbearian
+        - MikeHolman
+        - NathanielMcVicar
+        - negiyas
+        - sstamenova
         - tjingrant
+        - tungld
+        - whitneywhtsang
     optimizer:
         - daquexian
         - fumihwh


### PR DESCRIPTION
I updated the list of ONNX-MLIR contributors. The first criteria I used was the number of contributions as number of PRs from April 2021 to April 2022. I picked everyone that had 10 or more PRs. Then I looked at the folks in the 5-10 PRs and determined that this group also contributed in many other ways, from attending weekly meeting, presenting influential contributions to our infrastructure, as well as heavily participating in the accelerator code that was donated this year by IBM to the onnx-mlir project.

Signed-off-by: Alexandre Eichenberger <alexe@us.ibm.com>