### PR TITLE
Add a new Compilers SIG

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ The current list of Contributors and Approvers in the SIGs are listed in the [CO
 | Name      | Responsibilities    |
 | ------------------ | ------------- |
 | [Architecture & Infra](infra) | Defining and maintaining the core ONNX format, the build and CI/CD systems for ONNX repositories, publishing release packages for ONNX, the onnx-docker repository, and creating tools to help integrate with and test against the ONNX standard. This SIG is also the defacto owner of files in the main ONNX repository unless explicitly owned by another SIG. |
+| [Compilers](compilers) | Developing and maintaining core compiler technology optimizing and lowering ONNX format. |
 | [Operators](operators) | Determining the operators that are part of the ONNX spec (ONNX and ONNX-ML domains), ensuring high quality operator definitions and documentation, establishing criteria for adding new operators, managing ops domains and compliance tiers, and enforcing versioning mechanisms. |
 | [Converters](converters) | Developing and maintaining the various converter repositories under ONNX. |
 | [Models and tutorials](models-tutorials) | Providing a comprehensive collection of state of the art ONNX models from a variety of sources and making it easy for users to get started with ONNX and the ecosystem around it. |

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The current list of Contributors and Approvers in the SIGs are listed in the [CO
 | Name      | Responsibilities    |
 | ------------------ | ------------- |
 | [Architecture & Infra](infra) | Defining and maintaining the core ONNX format, the build and CI/CD systems for ONNX repositories, publishing release packages for ONNX, the onnx-docker repository, and creating tools to help integrate with and test against the ONNX standard. This SIG is also the defacto owner of files in the main ONNX repository unless explicitly owned by another SIG. |
-| [Compilers](compilers) | Developing and maintaining core compiler technology optimizing and lowering ONNX format. |
+| [Compilers](compilers) | Developing and maintaining core compiler technology for optimizing and lowering ONNX format. |
 | [Operators](operators) | Determining the operators that are part of the ONNX spec (ONNX and ONNX-ML domains), ensuring high quality operator definitions and documentation, establishing criteria for adding new operators, managing ops domains and compliance tiers, and enforcing versioning mechanisms. |
 | [Converters](converters) | Developing and maintaining the various converter repositories under ONNX. |
 | [Models and tutorials](models-tutorials) | Providing a comprehensive collection of state of the art ONNX models from a variety of sources and making it easy for users to get started with ONNX and the ecosystem around it. |

--- a/compilers/README.md
+++ b/compilers/README.md
@@ -3,11 +3,11 @@
 # ONNX Compiler Special Interest Group (SIG)
 
 This is the working repo for the Compiler Special Interest Group (SIG), which is responsible for compiler solutions that optimizes and lower ONNX core format file to representations that are fed to further compilers, runtimes, or directly executed.
-The compiler solutions investigated by this SIG consumes ONNX core files defined by the Architecture & Infrastrucutre SIG and uses ONNX operations defined by the Operator SIG.
-This SIG is open to solutions developped any relevant compiler infrastructures.
-Projects sponsored by this SIG may work in specific, open-sourced, compiler infrastructures.
+The compiler solutions investigated by this SIG predominantly consumes ONNX core files as defined by the Architecture & Infrastrucutre SIG and uses ONNX operations as defined by the Operator SIG.
+This SIG is open to solutions developped in any relevant, open-sourced compiler-frameworks and may sponsor projects that work in specific compiler frameworks.
+This SIG also invite discussions on making the ONNX standard more amendable to compiler technology. 
 
-This repo contains all the artifacts, materials, meeting notes and proposals regarding the Compiler SIG.
+This repo contains all the artifacts, materials, meeting notes, and proposals regarding the Compiler SIG.
 
 Feedbacks and contributions are welcome.
 
@@ -15,17 +15,17 @@ Feedbacks and contributions are welcome.
 Please sign up at https://slack.lfai.foundation/ and join [onnx-compilers](https://lfaifoundation.slack.com/archives/C01B38FP2AV) channel.
 <!--- slack channels to be created / renamed if proposal is accepted -->
 
-## SIG Leads
+## SIG Lead(s)
 
 * Alexandre Eichenberger (IBM)
 * TBD
 
 ## Logistics
 
-* SIG leads will drive the monthly Compiler SIG meeting.
+* SIG lead(s) will drive the monthly Compiler SIG meeting.
 * Meeting annoucement will be posted in our Slack channel.
 * Specific Compiler-SIG projects may meet at a higher frequency.
-  * SIG leads may delegate leadership of project meetings to respective project technical leads.
+  * SIG lead(s) may delegate leadership of project meetings to their respective project technical lead(s).
   * Monthly Compiler SIG meetings may take place at the begining of a specific project meeting.
 * Feedbacks and topic request are welcome by all.
 
@@ -40,9 +40,9 @@ Please sign up at https://slack.lfai.foundation/ and join [onnx-compilers](https
 
 ## Current projects(s)
 
-* Onnx-mlir: ONNX compiler lowering ONNX representation to other MLIR representations, including LLVM representation for ingestion in the LLVM compiler.
+* Onnx-mlir: lowering ONNX representation to other MLIR representations, including representations for ingestion in the LLVM compiler.
   * Description: [High Level](https://www.onnx.ai/onnx-mlir), [GitHub](https://github.com/onnx/onnx-mlir).
-  * Meeting [notes](https://github.com/onnx/onnx-mlir/wiki/Informal-meeting-agenda-and-notes).
+  * Meeting [agneda and notes](https://github.com/onnx/onnx-mlir/wiki/Informal-meeting-agenda-and-notes).
   * Slack channel: [onnx-mlir](https://lfaifoundation.slack.com/archives/C01B38FP2AV)
 
 

--- a/compilers/README.md
+++ b/compilers/README.md
@@ -1,0 +1,48 @@
+<!--- SPDX-License-Identifier: Apache-2.0 -->
+
+# ONNX Compiler Special Interest Group (SIG)
+
+This is the working repo for the Compiler Special Interest Group (SIG), which is responsible for compiler solutions that optimizes and lower ONNX core format file to representations that are fed to further compilers, runtimes, or directly executed.
+The compiler solutions investigated by this SIG consumes ONNX core files defined by the Architecture & Infrastrucutre SIG and uses ONNX operations defined by the Operator SIG.
+This SIG is open to solutions developped any relevant compiler infrastructures.
+Projects sponsored by this SIG may work in specific, open-sourced, compiler infrastructures.
+
+This repo contains all the artifacts, materials, meeting notes and proposals regarding the Compiler SIG.
+
+Feedbacks and contributions are welcome.
+
+## Slack channel
+Please sign up at https://slack.lfai.foundation/ and join [onnx-compilers](https://lfaifoundation.slack.com/archives/C01B38FP2AV) channel.
+<!--- slack channels to be created / renamed if proposal is accepted -->
+
+## SIG Leads
+
+* Alexandre Eichenberger (IBM)
+* TBD
+
+## Logistics
+
+* SIG leads will drive the monthly Compiler SIG meeting.
+* Meeting annoucement will be posted in our Slack channel.
+* Specific Compiler-SIG projects may meet at a higher frequency.
+  * SIG leads may delegate leadership of project meetings to respective project technical leads.
+  * Monthly Compiler SIG meetings may take place at the begining of a specific project meeting.
+* Feedbacks and topic request are welcome by all.
+
+## Discussion
+
+* Slack channel https://lfaifoundation.slack.com/archives/C018Y2QG7V2
+* Documents and artifacts: https://github.com/onnx/sigs/tree/master/compilers
+
+## Meeting notes
+
+* Compiler SIG meeting notes are kept in the [meeting](meetings) folder. 
+
+## Current projects(s)
+
+* Onnx-mlir: ONNX compiler lowering ONNX representation to other MLIR representations, including LLVM representation for ingestion in the LLVM compiler.
+  * Description: [High Level](https://www.onnx.ai/onnx-mlir), [GitHub](https://github.com/onnx/onnx-mlir).
+  * Meeting [notes](https://github.com/onnx/onnx-mlir/wiki/Informal-meeting-agenda-and-notes).
+  * Slack channel: [onnx-mlir](https://lfaifoundation.slack.com/archives/C01B38FP2AV)
+
+

--- a/compilers/README.md
+++ b/compilers/README.md
@@ -5,7 +5,7 @@
 This is the working repo for the Compiler Special Interest Group (SIG), which is responsible for compiler solutions that optimizes and lower ONNX core format file to representations that are fed to further compilers, runtimes, or directly executed.
 The compiler solutions investigated by this SIG predominantly consumes ONNX core files as defined by the Architecture & Infrastrucutre SIG and uses ONNX operations as defined by the Operator SIG.
 This SIG is open to solutions developped in any relevant, open-sourced compiler-frameworks and may sponsor projects that work in specific compiler frameworks.
-This SIG also invite discussions on making the ONNX standard more amendable to compiler technology. 
+This SIG also invite discussions on making the ONNX standard more amendable to compiler technology.
 
 This repo contains all the artifacts, materials, meeting notes, and proposals regarding the Compiler SIG.
 
@@ -18,7 +18,7 @@ Please sign up at https://slack.lfai.foundation/ and join [onnx-compilers](https
 ## SIG Lead(s)
 
 * Alexandre Eichenberger (IBM)
-* TBD
+* Philip Lassen (Groq)
 
 ## Logistics
 
@@ -42,7 +42,7 @@ Please sign up at https://slack.lfai.foundation/ and join [onnx-compilers](https
 
 * Onnx-mlir: lowering ONNX representation to other MLIR representations, including representations for ingestion in the LLVM compiler.
   * Description: [High Level](https://www.onnx.ai/onnx-mlir), [GitHub](https://github.com/onnx/onnx-mlir).
-  * Meeting [agneda and notes](https://github.com/onnx/onnx-mlir/wiki/Informal-meeting-agenda-and-notes).
+  * Meeting [agenda and notes](https://github.com/onnx/onnx-mlir/wiki/Informal-meeting-agenda-and-notes).
   * Slack channel: [onnx-mlir](https://lfaifoundation.slack.com/archives/C01B38FP2AV)
 
 


### PR DESCRIPTION
Added changes to the repo to introduce a Compilers SIG. If accepted, will create relevant slack channel and investigate a co-leader, if anyone is interested in helping out.

Changes would also have to be done to the steering committee repo, presumably that would be done if this PR is accepted

Signed-off-by: Alexandre Eichenberger <alexe@us.ibm.com>