### PR TITLE
Update of list for SIG-Compiler

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -85,40 +85,26 @@ SIG-modelstutorials:
         - wenbingl
 
 SIG-compilers:
-     - AlexandreEichenberger
      - BraunPhilipp
      - MikeHolman
-     - NathanielMcVicar
      - Silvan-K
      - ashay
-     - caoimhinuibrian
      - chenchongsong
-     - chentong319
      - christopherbate
-     - cjvolzka
      - doru1004
      - etiotto
      - eric-k256
      - gargaroff
      - gongsu832
      - gramalingam
-     - hamptonm1
-     - imaihal
      - jcwchen
      - kevcadieux
      - ljfitz
      - manbearian
-     - maxbartel
      - messerb5467
-     - mikeessen
      - mmoldawsky
-     - negiyas
-     - philass
      - rdicecco
-     - sorenlassen
-     - sstamenova
      - tjingrant
-     - tungld
      - weonyuan
      - whitneywhtsang
      - yaochengji
@@ -128,10 +114,8 @@ SIG-compilers:
          - caoimhinuibrian
          - chentong319
          - cjvolzka
-         - gongsu832
          - hamptonm1
          - imaihal
-         - jcwchen
          - maxbartel
          - mikeessen
          - negiyas
@@ -139,7 +123,7 @@ SIG-compilers:
          - sorenlassen
          - sstamenova
          - tungld
-
+  
 SIG-chairs:
     - AlexandreEichenberger
     - askhade

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -61,12 +61,8 @@ SIG-operators:
         - postrational
         - wschin
         - xadupre
-<<<<<<< HEAD
-  
-=======
         - yuanyao-nv
 
->>>>>>> main
 SIG-converters:
     - tjingrant
     - TomWildenhain-Microsoft
@@ -75,7 +71,6 @@ SIG-converters:
         - kevinch-nv
         - wenbingl
         - wschin
-
 
 SIG-modelstutorials:
     - AK391
@@ -131,7 +126,7 @@ SIG-compilers:
          - sorenlassen
          - sstamenova
          - tungld
-  
+
 SIG-chairs:
     - AlexandreEichenberger
     - askhade
@@ -146,7 +141,6 @@ WG-chairs:
     - chinhuang007
     - jantonguirao
     - sveta-levitan
-
 
 Steering-Committee:
     - andife

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -98,6 +98,7 @@ SIG-compilers:
      - cjvolzka
      - doru1004
      - etiotto
+     - eric-k256
      - gargaroff
      - gongsu832
      - gramalingam

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -28,23 +28,6 @@ SIG-archinfra:
     - yuanbyu
     - yuslepukhin
     releasemgrs:
-    mlir:
-        - AlexandreEichenberger
-        - caoimhinuibrian
-        - chentong319
-        - doru1004
-        - etiotto
-        - gongsu832
-        - gramalingam
-        - imaihal
-        - manbearian
-        - MikeHolman
-        - NathanielMcVicar
-        - negiyas
-        - sstamenova
-        - tjingrant
-        - tungld
-        - whitneywhtsang
     optimizer:
         - daquexian
         - fumihwh
@@ -66,19 +49,19 @@ SIG-operators:
     - hariharans29
     - liuyu21
     - matteosal
+    - p-wysocki
     - shinh
     - shubhambhokare1
     - skottmckay
     - yufenglee
-    - p-wysocki
     approvers:
         - askhade
+        - daquexian
         - gramalingam
         - postrational
         - wschin
-        - daquexian
         - xadupre
-
+  
 SIG-converters:
     - tjingrant
     - TomWildenhain-Microsoft
@@ -101,15 +84,70 @@ SIG-modelstutorials:
         - prasanthpul
         - wenbingl
 
+SIG-compilers:
+     - AlexandreEichenberger
+     - BraunPhilipp
+     - MikeHolman
+     - NathanielMcVicar
+     - Silvan-K
+     - ashay
+     - caoimhinuibrian
+     - chenchongsong
+     - chentong319
+     - christopherbate
+     - cjvolzka
+     - doru1004
+     - etiotto
+     - gargaroff
+     - gongsu832
+     - gramalingam
+     - hamptonm1
+     - imaihal
+     - jcwchen
+     - kevcadieux
+     - ljfitz
+     - manbearian
+     - maxbartel
+     - messerb5467
+     - mikeessen
+     - mmoldawsky
+     - negiyas
+     - philass
+     - rdicecco
+     - sorenlassen
+     - sstamenova
+     - tjingrant
+     - tungld
+     - weonyuan
+     - whitneywhtsang
+     - yaochengji
+     approvers:
+         - AlexandreEichenberger
+         - NathanielMcVicar
+         - caoimhinuibrian
+         - chentong319
+         - cjvolzka
+         - gongsu832
+         - hamptonm1
+         - imaihal
+         - jcwchen
+         - maxbartel
+         - mikeessen
+         - negiyas
+         - philass
+         - sorenlassen
+         - sstamenova
+         - tungld
 
 SIG-chairs:
+    - AlexandreEichenberger
     - askhade
     - gramalingam
     - jcwchen
     - kevinch-nv
     - linkerzhang
+    - philass
     - postrational
-
 
 WG-chairs:
     - chinhuang007


### PR DESCRIPTION
Added the name for the sig-compiler, including all top contributors (2 or more consequential PR over last year). Approver list is longer than for other groups, and it's ok as PR get reviewed by folks all the time.

This PR started from #150