### PR TITLE
Add Yuan Yao to op sig approvers

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -78,6 +78,7 @@ SIG-operators:
         - wschin
         - daquexian
         - xadupre
+        - yuanyao-nv
 
 SIG-converters:
     - tjingrant


### PR DESCRIPTION
I suggest that Yuan Yao be added to the operator SIG approver list. He has been contributing to the ONNX spec regularly, and will also be the release manager for the upcoming ONNX release.