### PR TITLE
Update contributors list based on contributions since last year

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -27,6 +27,11 @@ SIG-archinfra:
     - xuzijian629
     - yuanbyu
     - yuslepukhin
+    - andife
+    - justinchuby
+    - garymm
+    - take-cheeze
+    - natke
     releasemgrs:
         - yuanyao-nv
     optimizer:
@@ -54,6 +59,13 @@ SIG-operators:
     - skottmckay
     - thiagocrepaldi
     - yufenglee
+    - jantonguirao
+    - xuzijian629
+    - jbachurski
+    - smk2007
+    - philass
+    - sechkova
+    - AlexandreEichenberger
     approvers:
         - askhade
         - daquexian


### PR DESCRIPTION
Based on PRs created from Jan 1, 2022 onwards (and taking other participation into account).