### PR TITLE
change justin as approver of archinfra WG

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -28,7 +28,6 @@ SIG-archinfra:
     - yuanbyu
     - yuslepukhin
     - andife
-    - justinchuby
     - garymm
     - take-cheeze
     - natke
@@ -42,6 +41,7 @@ SIG-archinfra:
         - etiotto
         - gramalingam
         - jcwchen
+        - justinchuby
         - linkerzhang
         - liqunfu
         - prasanthpul


### PR DESCRIPTION
justinchuby has been actively working on ONNX repo for more than a year. He has made many improvements to ensure high quality of the project. He has added many new features, and been reviewing PRs from other contributors, and involved with discussion on many aspects of the ONNX project. His is also working on ORT and pytorch converter thus he is in a position to make ONNX a highly useful platform for the AI community. 
