### PR TITLE
Add a co-lead for models-tutorials SIG

### DIFF
--- a/models-tutorials/README.md
+++ b/models-tutorials/README.md
@@ -12,6 +12,7 @@ Feedback and contributions are welcome.
 Please sign up at https://slack.lfai.foundation/ and join [onnx-modelzoo](https://lfaifoundation.slack.com/archives/C018RE2BRBL) channel.
 
 # SIG Leads
+* Ramakrishnan Sivakumar (AMD): April 2023 - Current
 * Jacky Chen (Microsoft): February 2022 - Current
 * Wenbing Li (Microsoft): September 2020 - February 2022
 * Vinitra Swamy (Microsoft): January 2020 - September 2020


### PR DESCRIPTION
Follow-up PR for https://github.com/onnx/sigs/pull/164. Add a new co-lead: Ramakrishnan Sivakumar for models-tutorials SIG. Ramakrishnan Sivakumar from AMD is interested in joining the co-leads of SIG-modelstutorials to help PR/issues/proposal reviews in ONNX Model Zoo. He and I will work intensively to bring more the state-of-art models into the zoo. Therefore, I, as the current lead of models-tutorials SIG, nominate Ramakrishnan Sivakumar for the co-lead of SIG-modelstutorials.

cc @ramkrishna2910 