### PR TITLE
Add abock to SIG-archinfra

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -10,6 +10,7 @@
 # Please keep each section sorted alphabetically!
 
 SIG-archinfra:
+    - abock
     - annajung
     - chinhuang007
     - chudegao


### PR DESCRIPTION
@abock is leading the ONNX and ONNX converter teams at Microsoft and is a contributor to ONNX.

@prasanthpul @gramalingam