### PR TITLE
Add model zoo approvers

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -100,7 +100,9 @@ SIG-modelstutorials:
     - yuwenzho
     approvers:
         - andife
+        - danielholanda
         - jcwchen
+        - jeremyfowers
         - prasanthpul
         - ramkrishna2910
         - wenbingl


### PR DESCRIPTION
I would like to add Daniel Holanda and Jeremy Fowers from AMD to the approver's list for the models and tutorials SIG. They are key contributors to the TunrkeyML project that now powers the ONNX Model ZOO.
Their involvement in the SIG would help improve the quality of models and the toolchain that the onnx community uses.
