### PR TITLE
Update CONTRIBUTORS

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -34,9 +34,6 @@ SIG-archinfra:
     - natke
     releasemgrs:
         - yuanyao-nv
-    optimizer:
-        - daquexian
-        - fumihwh
     approvers:
         - askhade
         - etiotto
@@ -154,10 +151,11 @@ SIG-compilers:
          - tungld
 
 SIG-optimizations:
-    - freddychiu
-    - justinchuby
     - rktreddy
     - thuang6
+    optimizer:
+        - daquexian
+        - fumihwh
     approvers:
         - freddychiu
         - justinchuby


### PR DESCRIPTION
Move optimizers group from archinfra to new optimizations SIG. Fix optimizations list so people are only listed in one place, since the groups are nested