### PR TITLE
Update contributors

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -11,6 +11,7 @@
 
 SIG-archinfra:
     - abock
+    - askhade
     - annajung
     - chinhuang007
     - chudegao
@@ -35,7 +36,6 @@ SIG-archinfra:
     releasemgrs:
         - yuanyao-nv
     approvers:
-        - askhade
         - etiotto
         - gramalingam
         - jcwchen
@@ -47,6 +47,7 @@ SIG-archinfra:
         - xadupre
 
 SIG-operators:
+    - askhade
     - bowenbao
     - hariharans29
     - liuyu21
@@ -65,8 +66,8 @@ SIG-operators:
     - sechkova
     - AlexandreEichenberger
     approvers:
-        - askhade
         - daquexian
+        - justinchuby
         - gramalingam
         - postrational
         - wschin

--- a/operators/meetings/046-20240201.md
+++ b/operators/meetings/046-20240201.md
@@ -1,0 +1,101 @@
+# Thursday, February 1st, 2024 at 9:00am PST
+
+## Agenda
+
+[Issue #5776](https://github.com/onnx/onnx/issues/5776)
+
+
+## Attendees
+
+* Aditya Goel (Quantco)
+* Alexandre Eichenberger (IBM)
+* Andreas Fehlner (TRUMPf)
+* Charles Volzka (IBM)
+* Ganesan Ramalingam (Microsoft)
+* Justin Chu (Microsoft)
+* Liqun Fu (Microsoft)
+* Michal Karzynski (Intel)
+* Rajeev Rao (Nvidia)
+* Xavier Dupré (Microsoft)
+* Yuan Yao (Nvidia)
+
+### Next Release (1.16)
+
+Charles Volzka (IBM) is the release manager for the upcoming release of ONNX.
+The code-freeze is tentatively targeted around Feb 23rd.
+The release validation is expected to take around three weeks, with the release
+happening sometime in late March.
+
+### Swish/SiLU operator: [Issue #5853](https://github.com/onnx/onnx/issues/5853)
+
+The issue discussed was whether adding this operator to the standard was appropriate
+given that it can be easily expressed using other operators. The conclusion was that,
+as long as the operator is important and used in important models, adding it as a
+function op is justified.
+
+One question that was brought up was that the attribute beta was usually learnt
+(during training) and how that should be handled. One answer was that this is
+true for similar attributes of various similar activation ops and that ONNX does
+nothing different for them. This made sense since ONNX is predominantly used for
+inference. For its use in training, however, converting the attribute to input
+might make sense. Alexandre pointed out that it was preferable to introduce
+a parameter as an input upfront instead of introducing it as an attribute parameter
+and promoting it to be an input later (which ends up creating extra work for
+backends like the ONNXMLIR compiler).
+
+### NaN Quantization: [Issue #5879](https://github.com/onnx/onnx/issues/5879)
+
+This issue points out that the spec of the quantization operator (to integral
+values) does not mention what happens when the input value is a NaN.
+
+Various options exist:
+* Declaring explicitly that the behavior is undefined
+* Defining the output value to be a special value (like zero or the smallest int
+value representable in the target type), which seems to be used in some numpy
+implementations
+* Requiring an exception to be thrown.
+
+A quick experimentation suggested that the Numpy behavior may be platform/version
+dependent.
+
+Another suggestion was that the behavior should be the same as that of Cast (from
+floating values to integral values). The conclusion was that the behavior should
+be consistent with Cast, and that this should be undefined behavior.
+
+Users who care about the behavior should explicitly use a conversion (such as
+Where(IsNan(x), some non-nan value, x)) on the input before quantization.
+
+### TreeEnsemble operator: PR [#5874](https://github.com/onnx/onnx/pull/5874)
+
+This PR introduces a new ONNX ML operator that generalizes the existing tree
+ensemble classifier and regression. The PR seems acceptable. There was a
+discussion about version conversion. The version converter does not yet
+support ONNX ML domain operators, which is an issue that needs to be addressed
+separately.
+
+### Block Quantization: PR [#5812](https://github.com/onnx/onnx/pull/5812)
+
+This PR is the second part of the adding support for INT4 quantization to ONNX.
+It introduces block quantization. The PR is ready, and there are no concerns
+with the PR. There was a question about the support for sizes that are not a
+multiple of the blocksize. The PR supports this case. The last block may be
+an incomplete block in this case.
+
+### SVD operator and new domain support [#5821](https://github.com/onnx/onnx/pull/5821)
+
+This PR tackles two issues. It adds a new SVD operator (which has been previously
+attempted too). It also takes this as an opportunity to introduce a new domain
+for operators.
+
+There was a discussion about what the domain name should be. There were two
+competing points of view.
+
+One was to introduce a single broad domain that could be used by a wide range
+of operators (like both ImageDecoder and SVD). This was the basis for suggesting
+a domain focused on "pre and post processing ops" or "data processing ops".
+
+A second was introduce a more focused domain, like "linalg" or "linear algebra"
+(for ops like SVD).
+
+There was no consensus on a suitable domain name. However, there was consensus
+that "pnp" was cryptic and not a suitable name.

--- a/operators/meetings/046-20240201.md
+++ b/operators/meetings/046-20240201.md
@@ -1,10 +1,5 @@
 # Thursday, February 1st, 2024 at 9:00am PST
 
-## Agenda
-
-[Issue #5776](https://github.com/onnx/onnx/issues/5776)
-
-
 ## Attendees
 
 * Aditya Goel (Quantco)


### PR DESCRIPTION
I propose replacing Ashwini with Justin in the Operator SIG approvers list. This makes sense, given the changes in roles for both of them. Justin has already been the most significant contributor to the ONNX repo, especially with regards to reviewing PRs as well, for quite a while now.