### PR TITLE
Add sig-operators contributors

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -52,6 +52,8 @@ SIG-archinfra:
 SIG-operators:
     - askhade
     - bowenbao
+    - cbourjau
+    - fdwr
     - hariharans29
     - liuyu21
     - matteosal


### PR DESCRIPTION
Given the frequent contributions @fdwr and @cbourjau made. I propose that we add them as contributors in the operators sig. 